### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -333,7 +333,7 @@ epub_copyright = copyright
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 

--- a/tonnikala/tests/test_js_templates.py
+++ b/tonnikala/tests/test_js_templates.py
@@ -189,18 +189,18 @@ class TestJsTemplates(unittest.TestCase):
 """
     def test_translation(self):
         fragment = '<html alt="foo"> abc </html>'
-        self.are('<html alt="foo"> abc </html>', fragment, debug=False, translateable=True)
+        self.are('<html alt="foo"> abc </html>', fragment, debug=False, translatable=True)
 
         def gettext(x):
             return '<"%s&>' % x
 
         self.are('<html alt="&lt;&#34;foo&amp;&gt;"> &lt;&#34;abc&amp;&gt; </html>',
-            fragment, debug=False, translateable=True, gettext=gettext)
+            fragment, debug=False, translatable=True, gettext=gettext)
 
         def gettext(x):
             return '<%s' % x
 
-        self.are('<html>&lt;&gt;</html>', '<html>&gt;</html>', debug=False, translateable=True, gettext=gettext)
+        self.are('<html>&lt;&gt;</html>', '<html>&gt;</html>', debug=False, translatable=True, gettext=gettext)
 
     def assert_file_rendering_equals(self, input_file, output_file, debug=False, **context):
         loader = get_loader(debug=debug)


### PR DESCRIPTION
There are small typos in:
- docs/conf.py
- tonnikala/tests/test_js_templates.py

Fixes:
- Should read `translatable` rather than `translateable`.
- Should read `that` rather than `shat`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md